### PR TITLE
Display achievement's description in compact view tooltip

### DIFF
--- a/Views/Interface/SuccessStoryAchievementsCompact.xaml.cs
+++ b/Views/Interface/SuccessStoryAchievementsCompact.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Media;
 using System.Windows.Media.Effects;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
+using System.Windows.Documents;
 
 namespace SuccessStory.Views.Interface
 {
@@ -196,17 +197,27 @@ namespace SuccessStory.Views.Interface
                     {
                         if (i < nbGrid - 1)
                         {
+                            TextBlock tooltip = new TextBlock();
+                            tooltip.Inlines.Add(new Run(AchievementsList[i].Name)
+                            {
+                                FontWeight = FontWeights.Bold
+                            });
+                            tooltip.Inlines.Add(new LineBreak());
+                            tooltip.Inlines.Add(new Run(AchievementsList[i].Description));
+
                             Image gridImage = new Image();
                             gridImage.Stretch = Stretch.UniformToFill;
                             gridImage.Width = 48;
                             gridImage.Height = 48;
-                            gridImage.ToolTip = AchievementsList[i].Name;
+                            gridImage.ToolTip = tooltip;
                             gridImage.SetValue(Grid.ColumnProperty, i);
 
                             if (_withUnlocked)
                             {
                                 var converter = new LocalDateTimeConverter();
-                                gridImage.ToolTip = AchievementsList[i].NameWithDateUnlock;
+
+                                var nameRun = (Run) tooltip.Inlines.FirstInline;
+                                nameRun.Text = AchievementsList[i].NameWithDateUnlock;
                             }
 
                             if (AchievementsList[i].IsGray)

--- a/Views/Interface/SuccessStoryAchievementsCompactVertical.xaml.cs
+++ b/Views/Interface/SuccessStoryAchievementsCompactVertical.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Media;
 using System.Windows.Media.Effects;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
+using System.Windows.Documents;
 
 namespace SuccessStory.Views.Interface
 {
@@ -201,17 +202,27 @@ namespace SuccessStory.Views.Interface
                     {
                         if (i < nbRow - 1)
                         {
+                            TextBlock tooltip = new TextBlock();
+                            tooltip.Inlines.Add(new Run(AchievementsList[i].Name)
+                            {
+                                FontWeight = FontWeights.Bold
+                            });
+                            tooltip.Inlines.Add(new LineBreak());
+                            tooltip.Inlines.Add(new Run(AchievementsList[i].Description));
+
                             Image gridImage = new Image();
                             gridImage.Stretch = Stretch.UniformToFill;
                             gridImage.Width = 48;
                             gridImage.Height = 48;
-                            gridImage.ToolTip = AchievementsList[i].Name;
+                            gridImage.ToolTip = tooltip;
                             gridImage.SetValue(Grid.RowProperty, i);
 
                             if (_withUnlocked)
                             {
                                 var converter = new LocalDateTimeConverter();
-                                gridImage.ToolTip = AchievementsList[i].NameWithDateUnlock;
+
+                                var nameRun = (Run) tooltip.Inlines.FirstInline;
+                                nameRun.Text = AchievementsList[i].NameWithDateUnlock;
                             }
 
                             if (AchievementsList[i].IsGray)


### PR DESCRIPTION
Adding the achievement's description to the tooltip inside the compact view lets the player know what to do to achieve it without having to move to the game's full achievement list, thus gaining some time and removing some friction for the user.

Here is the result:
![image](https://user-images.githubusercontent.com/13206601/132260864-06ecfaf5-73f0-4612-b35d-52da2fa0ea00.png)
