### PR TITLE
Respect RetroAchievements enable/disable setting

### DIFF
--- a/source/SuccessStory.cs
+++ b/source/SuccessStory.cs
@@ -189,7 +189,7 @@ namespace SuccessStory
                         }
                     }
 
- 
+
                     Window windowExtension = PlayniteUiHelper.CreateExtensionWindow(PlayniteApi, resources.GetString("LOCSuccessStory"), ViewExtension, windowOptions);
                     if (windowOptions.ShowMaximizeButton)
                     {
@@ -397,7 +397,7 @@ namespace SuccessStory
                                     {
                                         ViewExtension = new SuccessStoryCategoryView(GameMenu);
                                     }
-                                    else 
+                                    else
                                     {
                                         ViewExtension = new SuccessStoryOneGameView(GameMenu);
                                     }
@@ -598,9 +598,9 @@ namespace SuccessStory
             {
                 MenuSection = resources.GetString("LOCSuccessStory"),
                 Description = "Test",
-                Action = (mainMenuItem) => 
+                Action = (mainMenuItem) =>
                 {
-                    
+
                 }
             });
 #endif
@@ -774,7 +774,7 @@ namespace SuccessStory
             {
                 MenuSection = MenuInExtensions + resources.GetString("LOCSuccessStory"),
                 Description = "Test",
-                Action = (mainMenuItem) => 
+                Action = (mainMenuItem) =>
                 {
 
                 }
@@ -817,7 +817,7 @@ namespace SuccessStory
                             string SourceName = PlayniteTools.GetSourceName(game);
 
                             if (gameAchievements.IsManual)
-                            {                                
+                            {
                                 int AppId = steamApi.GetAppId(gameAchievements.Name);
 
                                 if (AppId != 0)
@@ -971,7 +971,7 @@ namespace SuccessStory
                 }
             });
         }
-        #endregion  
+        #endregion
 
 
         #region Application event
@@ -979,7 +979,7 @@ namespace SuccessStory
         public override void OnApplicationStarted(OnApplicationStartedEventArgs args)
         {
             // TODO - Removed for Playnite 11
-            if (!PluginSettings.Settings.PurgeImageCache) 
+            if (!PluginSettings.Settings.PurgeImageCache)
             {
                 PluginDatabase.ClearCache();
                 PluginSettings.Settings.PurgeImageCache = true;
@@ -1011,15 +1011,15 @@ namespace SuccessStory
                             return;
                         }
 
-                        x.Items.ForEach(y => 
+                        x.Items.ForEach(y =>
                         {
                             if (ct.IsCancellationRequested)
                             {
                                 return;
                             }
 
-                            try 
-                            { 
+                            try
+                            {
                                 if (!y.ImageLockedIsCached)
                                 {
                                     var a = y.ImageLocked;
@@ -1069,7 +1069,7 @@ namespace SuccessStory
 
 
             // Initialize list console for RA
-            if (PluginSettings.Settings.RaConsoleAssociateds?.Count == 0)
+            if (PluginSettings.Settings.EnableRetroAchievements == true && PluginSettings.Settings.RaConsoleAssociateds?.Count == 0)
             {
                 PluginSettings.Settings.RaConsoleAssociateds = new List<RaConsoleAssociated>();
                 RA_Consoles ra_Consoles = RetroAchievements.GetConsoleIDs();


### PR DESCRIPTION
This prevents to access the retroachievements website if RetroAchievements are disabled in settings.

Currently SuccessStory always tries to access the retroachievements website even with retro achievements being disabled and no user / API key configured.