### PR TITLE
Fix parsing of trophy earned rate

### DIFF
--- a/source/Clients/PSNAchievements.cs
+++ b/source/Clients/PSNAchievements.cs
@@ -152,7 +152,7 @@ namespace SuccessStory.Clients
                     foreach (Trophie trophie in trophiesDetails?.trophies)
                     {
                         Trophie trophieUser = trophies.trophies.Where(x => x.trophyId == trophie.trophyId).FirstOrDefault();
-                        float.TryParse(trophieUser?.trophyEarnedRate.Replace(".", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator).Replace(",", CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator), out float Percent);
+                        float.TryParse(trophieUser?.trophyEarnedRate, NumberStyles.Float, CultureInfo.InvariantCulture, out float Percent);
 
                         AllAchievements.Add(new Achievements
                         {


### PR DESCRIPTION
Use invariant culture instead of replacing the decimal separator in the string.

Before the change, the decimal separator was ignored during parsing for me which resulted in incorrect percentages shown in Playnite:

![image](https://github.com/Lacro59/playnite-successstory-plugin/assets/1292060/8bd126b7-9bf3-4e83-97da-e550de249a55)

This was undoubtedly because of unusual locale settings in my profile (`sl-SI` as `CurrentCulture` with `,` as decimal separator, `en-US` as `CurrentUICulture` with `.` as decimal separator). However, using the `InvariantCulture` should make the parsing code work the same for everyone, no matter the user's locale settings.