### PR TITLE
Update ExophaseSearchResult.cs to use double

### DIFF
--- a/source/Models/ExophaseSearchResult.cs
+++ b/source/Models/ExophaseSearchResult.cs
@@ -58,7 +58,7 @@ namespace SuccessStory.Models
         public int found { get; set; }
         public object sort { get; set; }
         public object filters { get; set; }
-        public int pages { get; set; }
+        public double pages { get; set; }
         public List<List> list { get; set; }
         public Paging paging { get; set; }
     }


### PR DESCRIPTION
The Exophase API returns the pages attribute as a form like '1.0' rather than '1'. C# complains about the type, and stops the search.

The code does not end up using the data, but it needs to be specified for the serialization.

Changing it to a double fixes the search.

Should fix #417.