### PR TITLE
Steam achievements fix (including locked hidden achievements)

### DIFF
--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -901,16 +901,32 @@ namespace SuccessStory.Clients
                                     || !string.IsNullOrEmpty(x.UrlUnlocked) && new Uri(x.UrlUnlocked).PathAndQuery.IsEqual(new Uri(icongray).PathAndQuery);
                             });
 
+                            var achievementName = AchievementsData.Children?.Find(x => x.Name.IsEqual("displayName")).Value;
+                            var isHidden = AchievementsData.Children?.Find(x => x.Name.IsEqual("hidden")).Value == "1";
+
                             if (achievement != null)
                             {
                                 if (string.IsNullOrEmpty(achievement.ApiName))
                                 {
                                     achievement.ApiName = AchievementsData.Name;
                                 }
-                                achievement.Name = AchievementsData.Children?.Find(x => x.Name.IsEqual("displayName")).Value;
-                                achievement.IsHidden = AchievementsData.Children?.Find(x => x.Name.IsEqual("hidden")).Value == "1";
+
+                                achievement.Name = achievementName;
+                                achievement.IsHidden = isHidden;
                                 achievement.UrlUnlocked = icon;
                                 achievement.UrlLocked = icongray;
+                            }
+                            else
+                            {
+                                AllAchievements.Add(new Achievements
+                                {
+                                    Name = achievementName,
+                                    ApiName = AchievementsData.Name,
+                                    UrlUnlocked = icon,
+                                    UrlLocked = icongray,
+                                    DateUnlocked = default(DateTime),
+                                    IsHidden = isHidden,
+                                });
                             }
                         }
                     }
@@ -1308,17 +1324,20 @@ namespace SuccessStory.Clients
                             }
                         }
 
-                        Achievements.Add(new Achievements
+                        if (!Name.EndsWith(" hidden achievements remaining"))
                         {
-                            Name = WebUtility.HtmlDecode(Name),
-                            ApiName = string.Empty,
-                            Description = WebUtility.HtmlDecode(Description),
-                            UrlUnlocked = UrlUnlocked,
-                            UrlLocked = string.Empty,
-                            DateUnlocked = DateUnlocked,
-                            IsHidden = false,
-                            Percent = 100
-                        });
+                            Achievements.Add(new Achievements
+                            {
+                                Name = WebUtility.HtmlDecode(Name),
+                                ApiName = string.Empty,
+                                Description = WebUtility.HtmlDecode(Description),
+                                UrlUnlocked = UrlUnlocked,
+                                UrlLocked = string.Empty,
+                                DateUnlocked = DateUnlocked,
+                                IsHidden = false,
+                                Percent = 100
+                            });
+                        }
 
                         idx++;
                     }

--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -1288,9 +1288,9 @@ namespace SuccessStory.Clients
                         if (!stringDateUnlocked.IsNullOrEmpty())
                         {
                             stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Trim();
-                            if (!DateTime.TryParseExact(stringDateUnlocked, "dd MMM, yyyy @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked))
+                            if (!DateTime.TryParseExact(stringDateUnlocked, "d MMM, yyyy @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked))
                             {
-                                DateTime.TryParseExact(stringDateUnlocked, "dd MMM @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
+                                DateTime.TryParseExact(stringDateUnlocked, "d MMM @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
                             }
                         }
 

--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -35,7 +35,7 @@ namespace SuccessStory.Clients
 
         private bool IsLocal { get; set; } = false;
         private bool IsManual { get; set; } = false;
- 
+
         private static string SteamId { get; set; } = string.Empty;
         private static string SteamApiKey { get; set; } = string.Empty;
         private static string SteamUser { get; set; } = string.Empty;
@@ -956,7 +956,7 @@ namespace SuccessStory.Clients
 
 
         // TODO Use "profileurl" in "ISteamUser"
-        // TODO Utility after updated GetAchievementsByWeb() 
+        // TODO Utility after updated GetAchievementsByWeb()
         private string FindHiddenDescription(int AppId, string DisplayName, bool TryByName = false)
         {
             string url = string.Empty;
@@ -1259,44 +1259,44 @@ namespace SuccessStory.Clients
                         });
                     }
                 }
-                //else if (ResultWeb.IndexOf("achieveRow") > -1)
-                //{
-                //    Url = Url.Replace("&panorama=please", string.Empty).Replace($"l={LocalLang}", "l=english");
-                //    ResultWeb = Web.DownloadStringData(Url, GetCookies(), string.Empty, true).GetAwaiter().GetResult();
-                //    IHtmlDocument htmlDocument = new HtmlParser().Parse(ResultWeb);
-                //    var achieveRow_English = htmlDocument.QuerySelectorAll(".achieveRow");
-                //
-                //    htmlDocument = new HtmlParser().Parse(ResultWeb);
-                //    int idx = 0;
-                //    foreach(var el in htmlDocument.QuerySelectorAll(".achieveRow"))
-                //    {
-                //        string UrlUnlocked = el.QuerySelector(".achieveImgHolder img")?.GetAttribute("src") ?? string.Empty;
-                //        string Name = el.QuerySelector(".achieveTxtHolder h3").GetAttribute("src");
-                //        string Description = el.QuerySelector(".achieveTxtHolder h5").GetAttribute("src");
-                //
-                //        DateTime DateUnlocked = default(DateTime);
-                //        string stringDateUnlocked = achieveRow_English[idx].QuerySelector(".achieveUnlockTime")?.InnerHtml ?? string.Empty;
-                //        if (!stringDateUnlocked.IsNullOrEmpty())
-                //        {
-                //            stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Trim();
-                //            DateTime.TryParseExact(stringDateUnlocked, "dd MMM, yyyy @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
-                //        }
-                //
-                //        Achievements.Add(new Achievements
-                //        {
-                //            Name = WebUtility.HtmlDecode(Name),
-                //            ApiName = string.Empty,
-                //            Description = WebUtility.HtmlDecode(Description),
-                //            UrlUnlocked = UrlUnlocked,
-                //            UrlLocked = string.Empty,
-                //            DateUnlocked = DateUnlocked,
-                //            IsHidden = false,
-                //            Percent = 100
-                //        });
-                //
-                //        idx++;
-                //    }
-                //}
+                else if (ResultWeb.IndexOf("achieveRow") > -1)
+                {
+                    Url = Url.Replace("&panorama=please", string.Empty).Replace($"l={LocalLang}", "l=english");
+                    ResultWeb = Web.DownloadStringData(Url, GetCookies(), string.Empty, true).GetAwaiter().GetResult();
+                    IHtmlDocument htmlDocument = new HtmlParser().Parse(ResultWeb);
+                    var achieveRow_English = htmlDocument.QuerySelectorAll(".achieveRow");
+
+                    htmlDocument = new HtmlParser().Parse(ResultWeb);
+                    int idx = 0;
+                    foreach (var el in htmlDocument.QuerySelectorAll(".achieveRow"))
+                    {
+                        string UrlUnlocked = el.QuerySelector(".achieveImgHolder img")?.GetAttribute("src") ?? string.Empty;
+                        string Name = el.QuerySelector(".achieveTxtHolder h3").GetAttribute("src");
+                        string Description = el.QuerySelector(".achieveTxtHolder h5").GetAttribute("src");
+
+                        DateTime DateUnlocked = default(DateTime);
+                        string stringDateUnlocked = achieveRow_English[idx].QuerySelector(".achieveUnlockTime")?.InnerHtml ?? string.Empty;
+                        if (!stringDateUnlocked.IsNullOrEmpty())
+                        {
+                            stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Trim();
+                            DateTime.TryParseExact(stringDateUnlocked, "dd MMM, yyyy @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
+                        }
+
+                        Achievements.Add(new Achievements
+                        {
+                            Name = WebUtility.HtmlDecode(Name),
+                            ApiName = string.Empty,
+                            Description = WebUtility.HtmlDecode(Description),
+                            UrlUnlocked = UrlUnlocked,
+                            UrlLocked = string.Empty,
+                            DateUnlocked = DateUnlocked,
+                            IsHidden = false,
+                            Percent = 100
+                        });
+
+                        idx++;
+                    }
+                }
                 else
                 {
                     Common.LogDebug(true, $"No achievement data on {Url}");

--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -1193,6 +1193,22 @@ namespace SuccessStory.Clients
                         {
                             achievement.Percent = Percent;
                         }
+                        else
+                        {
+                            // locked hidden achievements aren't listed on user's achievement page
+                            AllAchievements.Add(new Achievements
+                            {
+                                Name = Name,
+                                ApiName = string.Empty,
+                                Description = WebUtility.HtmlDecode(achieveRow.QuerySelector("h5")?.InnerHtml?.Trim() ?? string.Empty),
+                                UrlUnlocked = achieveRow.QuerySelector(".achieveImgHolder img")?.GetAttribute("src") ?? string.Empty,
+                                UrlLocked = achieveRow.QuerySelector(".compareImg img")?.GetAttribute("src") ?? string.Empty,
+                                DateUnlocked = default(DateTime),
+                                IsHidden = true,
+                                Percent = Percent
+                            });
+                        }
+
                     }
                     catch (Exception ex)
                     {

--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -1271,7 +1271,7 @@ namespace SuccessStory.Clients
                 else if (ResultWeb.IndexOf("achieveRow") > -1)
                 {
                     Url = Url.Replace("&panorama=please", string.Empty).Replace($"l={LocalLang}", "l=english");
-                    ResultWeb = Web.DownloadStringData(Url, GetCookies(), string.Empty, true).GetAwaiter().GetResult();
+                    ResultWeb = Web.DownloadStringData(Url, cookies, string.Empty, true).GetAwaiter().GetResult();
                     IHtmlDocument htmlDocument = new HtmlParser().Parse(ResultWeb);
                     var achieveRow_English = htmlDocument.QuerySelectorAll(".achieveRow");
 

--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -890,13 +890,27 @@ namespace SuccessStory.Clients
                     {
                         foreach (KeyValue AchievementsData in SchemaForGame.Children?.Find(x => x.Name == "availableGameStats").Children?.Find(x => x.Name == "achievements").Children)
                         {
-                            Achievements achievement = AllAchievements.Find(x => x.ApiName.IsEqual(AchievementsData.Name));
+                            var icon = AchievementsData.Children?.Find(x => x.Name.IsEqual("icon")).Value;
+                            var icongray = AchievementsData.Children?.Find(x => x.Name.IsEqual("icongray")).Value;
+
+                            Achievements achievement;
+                            achievement = AllAchievements.Find(x =>
+                            {
+                                return x.ApiName.IsEqual(AchievementsData.Name)
+                                    || !string.IsNullOrEmpty(x.UrlUnlocked) && new Uri(x.UrlUnlocked).PathAndQuery.IsEqual(new Uri(icon).PathAndQuery)
+                                    || !string.IsNullOrEmpty(x.UrlUnlocked) && new Uri(x.UrlUnlocked).PathAndQuery.IsEqual(new Uri(icongray).PathAndQuery);
+                            });
 
                             if (achievement != null)
                             {
+                                if (string.IsNullOrEmpty(achievement.ApiName))
+                                {
+                                    achievement.ApiName = AchievementsData.Name;
+                                }
+                                achievement.Name = AchievementsData.Children?.Find(x => x.Name.IsEqual("displayName")).Value;
                                 achievement.IsHidden = AchievementsData.Children?.Find(x => x.Name.IsEqual("hidden")).Value == "1";
-                                achievement.UrlUnlocked = AchievementsData.Children?.Find(x => x.Name.IsEqual("icon")).Value;
-                                achievement.UrlLocked = AchievementsData.Children?.Find(x => x.Name.IsEqual("icongray")).Value;
+                                achievement.UrlUnlocked = icon;
+                                achievement.UrlLocked = icongray;
                             }
                         }
                     }

--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -890,9 +890,14 @@ namespace SuccessStory.Clients
                     {
                         foreach (KeyValue AchievementsData in SchemaForGame.Children?.Find(x => x.Name == "availableGameStats").Children?.Find(x => x.Name == "achievements").Children)
                         {
-                            AllAchievements.Find(x => x.ApiName.IsEqual(AchievementsData.Name)).IsHidden = AchievementsData.Children?.Find(x => x.Name.IsEqual("hidden")).Value == "1";
-                            AllAchievements.Find(x => x.ApiName.IsEqual(AchievementsData.Name)).UrlUnlocked = AchievementsData.Children?.Find(x => x.Name.IsEqual("icon")).Value;
-                            AllAchievements.Find(x => x.ApiName.IsEqual(AchievementsData.Name)).UrlLocked = AchievementsData.Children?.Find(x => x.Name.IsEqual("icongray")).Value;
+                            Achievements achievement = AllAchievements.Find(x => x.ApiName.IsEqual(AchievementsData.Name));
+
+                            if (achievement != null)
+                            {
+                                achievement.IsHidden = AchievementsData.Children?.Find(x => x.Name.IsEqual("hidden")).Value == "1";
+                                achievement.UrlUnlocked = AchievementsData.Children?.Find(x => x.Name.IsEqual("icon")).Value;
+                                achievement.UrlLocked = AchievementsData.Children?.Find(x => x.Name.IsEqual("icongray")).Value;
+                            }
                         }
                     }
                     catch (Exception ex)
@@ -1153,7 +1158,11 @@ namespace SuccessStory.Clients
                             Percent = float.Parse(achieveRow.QuerySelector(".achievePercent").InnerHtml.Replace("%", string.Empty).Replace(".", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator));
                         }
 
-                        AllAchievements.Find(x => x.Name.IsEqual(Name)).Percent = Percent;
+                        var achievement = AllAchievements.Find(x => x.Name.IsEqual(Name));
+                        if (achievement != null)
+                        {
+                            achievement.Percent = Percent;
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -1271,15 +1280,18 @@ namespace SuccessStory.Clients
                     foreach (var el in htmlDocument.QuerySelectorAll(".achieveRow"))
                     {
                         string UrlUnlocked = el.QuerySelector(".achieveImgHolder img")?.GetAttribute("src") ?? string.Empty;
-                        string Name = el.QuerySelector(".achieveTxtHolder h3").GetAttribute("src");
-                        string Description = el.QuerySelector(".achieveTxtHolder h5").GetAttribute("src");
+                        string Name = el.QuerySelector(".achieveTxtHolder h3").InnerHtml;
+                        string Description = el.QuerySelector(".achieveTxtHolder h5").InnerHtml;
 
                         DateTime DateUnlocked = default(DateTime);
-                        string stringDateUnlocked = achieveRow_English[idx].QuerySelector(".achieveUnlockTime")?.InnerHtml ?? string.Empty;
+                        string stringDateUnlocked = achieveRow_English[idx].QuerySelector(".achieveUnlockTime")?.TextContent ?? string.Empty;
                         if (!stringDateUnlocked.IsNullOrEmpty())
                         {
                             stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Trim();
-                            DateTime.TryParseExact(stringDateUnlocked, "dd MMM, yyyy @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
+                            if (!DateTime.TryParseExact(stringDateUnlocked, "dd MMM, yyyy @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked))
+                            {
+                                DateTime.TryParseExact(stringDateUnlocked, "dd MMM @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
+                            }
                         }
 
                         Achievements.Add(new Achievements

--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -1317,13 +1317,12 @@ namespace SuccessStory.Clients
                         string stringDateUnlocked = achieveRow_English[idx].QuerySelector(".achieveUnlockTime")?.TextContent ?? string.Empty;
                         if (!stringDateUnlocked.IsNullOrEmpty())
                         {
-                            stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Trim();
-                            if (!DateTime.TryParseExact(stringDateUnlocked, "d MMM, yyyy @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked))
+                            stringDateUnlocked = stringDateUnlocked.Replace("Unlocked", string.Empty).Trim() + " -7";
+                            if (!DateTime.TryParseExact(stringDateUnlocked, "d MMM, yyyy @ h:mmtt z", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked))
                             {
-                                DateTime.TryParseExact(stringDateUnlocked, "d MMM @ h:mmtt", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
+                                DateTime.TryParseExact(stringDateUnlocked, "d MMM @ h:mmtt z", new CultureInfo("en-US"), DateTimeStyles.None, out DateUnlocked);
                             }
                         }
-
                         if (!Name.EndsWith(" hidden achievements remaining"))
                         {
                             Achievements.Add(new Achievements


### PR DESCRIPTION
Based on Kryeker's PR #433. The extra commit includes an additional fix for #412: 

The original fix didn't parse hidden achievements not yet unlocked by the user because they aren't individually listed on the user's achievements stats page. Instead, the last row on the page only mentions how many there are:

![image](https://github.com/Lacro59/playnite-successstory-plugin/assets/1292060/2eeed5af-2410-4907-af0a-86260fa23dc7)

The extra commit parses those achievements from the global stats page: when the parser encounters an achievement that wasn't parsed yet, it adds it as a locked hidden achievement to the list instead of only updating the unlock percentage value.