### PR TITLE
Adjusted the way of conjugating the verb "ignore"

### DIFF
--- a/source/Localization/pt_BR.xaml
+++ b/source/Localization/pt_BR.xaml
@@ -20,8 +20,8 @@
     <sys:String x:Key="LOCSuccessStoryViewGames">Ver as conquistas dos jogos</sys:String>
     <sys:String x:Key="LOCSuccessStoryViewGame">Ver a conquista do jogo</sys:String>
 
-    <sys:String x:Key="LOCSuccessStoryIgnored">Ignorado o jogo</sys:String>
-    <sys:String x:Key="LOCSuccessStoryNotIgnored">Não ignorado o jogo</sys:String>
+    <sys:String x:Key="LOCSuccessStoryIgnored">Ignorar jogo</sys:String>
+    <sys:String x:Key="LOCSuccessStoryNotIgnored">Não ignorar jogo</sys:String>
 
     <sys:String x:Key="LOCSuccessStoryHiddenAchievement">Conquista oculta</sys:String>
 
@@ -91,7 +91,7 @@
     <sys:String x:Key="LOCSuccessStoryRefreshData">Recarregar dados</sys:String>
     <sys:String x:Key="LOCSuccessStoryGetMissing">Baixar dados faltando</sys:String>
     <sys:String x:Key="LOCSuccessStoryGetDataRecent">Jogos recentes com dados faltando</sys:String>
-    <sys:String x:Key="LOCSuccessStoryRefreshAllDataRecent">Partidas recentes</sys:String>
+    <sys:String x:Key="LOCSuccessStoryRefreshAllDataRecent">Jogos recentes</sys:String>
     <sys:String x:Key="LOCSuccessStoryRefreshAllData">Todos os jogos</sys:String>
     <sys:String x:Key="LOCSuccessStoryGetAllData">Todos os jogos com dados faltando</sys:String>
     <sys:String x:Key="LOCSuccessStoryGetDataInstalled">Jogos instalados com dados faltando</sys:String>


### PR DESCRIPTION
In Portuguese, the previous translation of "Ignore game" as "Ignorado o jogo" and "Un-ignore game" as "Não ignorado o jogo" has problems with context and verb agreement. The old translation turns the instruction, which should be a command or an action, into a description of the state of the game, which does not accurately represent the intention of the original text. I'm changing to the correct way.