### PR TITLE
[Epic Games] - Games with Apostrophes in the middle would result in 0 hits from querySearch

### DIFF
--- a/source/Clients/EpicAchievements.cs
+++ b/source/Clients/EpicAchievements.cs
@@ -38,7 +38,7 @@ namespace SuccessStory.Clients
                     string gameNameApostrophe = game.Name.Replace("'", "");
                     game.Links?.ForEach(x =>
                     {
-                        productSlug = EpicApi.GetProductSlugByUrl(x.Url).IsNullOrEmpty() ? productSlug : EpicApi.GetProductSlugByUrl(x.Url);
+                        productSlug = EpicApi.GetProductSlugByUrl(x.Url, gameNameApostrophe).IsNullOrEmpty() ? productSlug : EpicApi.GetProductSlugByUrl(x.Url, gameNameApostrophe);
                     });
 
                     if (productSlug.IsNullOrEmpty())

--- a/source/Clients/EpicAchievements.cs
+++ b/source/Clients/EpicAchievements.cs
@@ -35,6 +35,7 @@ namespace SuccessStory.Clients
                 try
                 {
                     string productSlug = string.Empty;
+                    string gameNameApostrophe = game.Name.Replace("'", "");
                     game.Links?.ForEach(x =>
                     {
                         productSlug = EpicApi.GetProductSlugByUrl(x.Url).IsNullOrEmpty() ? productSlug : EpicApi.GetProductSlugByUrl(x.Url);
@@ -42,7 +43,7 @@ namespace SuccessStory.Clients
 
                     if (productSlug.IsNullOrEmpty())
                     {
-                        productSlug = EpicApi.GetProductSlug(PlayniteTools.NormalizeGameName(game.Name));
+                        productSlug = EpicApi.GetProductSlug(PlayniteTools.NormalizeGameName(gameNameApostrophe));
                     }
 
                     if (productSlug.IsNullOrEmpty())
@@ -51,7 +52,7 @@ namespace SuccessStory.Clients
                         return null;
                     }
 
-                    string nameSpace = EpicApi.GetNameSpace(NormalizeGameName(game.Name), productSlug);
+                    string nameSpace = EpicApi.GetNameSpace(NormalizeGameName(gameNameApostrophe), productSlug);
                     if (nameSpace.IsNullOrEmpty())
                     {
                         Logger.Warn($"No NameSpace for the Epic game {game.Name}");

--- a/source/Clients/EpicAchievements.cs
+++ b/source/Clients/EpicAchievements.cs
@@ -35,15 +35,15 @@ namespace SuccessStory.Clients
                 try
                 {
                     string productSlug = string.Empty;
-                    string gameNameApostrophe = game.Name.Replace("'", "");
+                    string normalizedEpicName = NormalizeEpicName(game.Name);
                     game.Links?.ForEach(x =>
                     {
-                        productSlug = EpicApi.GetProductSlugByUrl(x.Url, gameNameApostrophe).IsNullOrEmpty() ? productSlug : EpicApi.GetProductSlugByUrl(x.Url, gameNameApostrophe);
+                        productSlug = EpicApi.GetProductSlugByUrl(x.Url, normalizedEpicName).IsNullOrEmpty() ? productSlug : EpicApi.GetProductSlugByUrl(x.Url, normalizedEpicName);
                     });
 
                     if (productSlug.IsNullOrEmpty())
                     {
-                        productSlug = EpicApi.GetProductSlug(PlayniteTools.NormalizeGameName(gameNameApostrophe));
+                        productSlug = EpicApi.GetProductSlug(normalizedEpicName);
                     }
 
                     if (productSlug.IsNullOrEmpty())
@@ -52,7 +52,7 @@ namespace SuccessStory.Clients
                         return null;
                     }
 
-                    string nameSpace = EpicApi.GetNameSpace(NormalizeGameName(gameNameApostrophe), productSlug);
+                    string nameSpace = EpicApi.GetNameSpace(normalizedEpicName, productSlug);
                     if (nameSpace.IsNullOrEmpty())
                     {
                         Logger.Warn($"No NameSpace for the Epic game {game.Name}");
@@ -186,6 +186,11 @@ namespace SuccessStory.Clients
                 }
             }
             return ProductSlug;
+        }
+
+        private string NormalizeEpicName(string GameName)
+        {
+            return PlayniteTools.NormalizeGameName(GameName.Replace("'", ""));
         }
         #endregion
     }


### PR DESCRIPTION
The Playnite tools for normalisation were moving apostrophes away from each other, removing them before normalisation as it resulted in games like "Thank Goodness You're Here!" to be normalised as "thank goodness you re here" and "Death Stranding Director's Cut" being "death stranding director s cut" which would give 0 results back from the store search