### PR TITLE
[Epic Games] Removing "," from name normalization 

### DIFF
--- a/source/Clients/EpicAchievements.cs
+++ b/source/Clients/EpicAchievements.cs
@@ -190,7 +190,7 @@ namespace SuccessStory.Clients
 
         private string NormalizeEpicName(string GameName)
         {
-            return PlayniteTools.NormalizeGameName(GameName.Replace("'", ""));
+            return PlayniteTools.NormalizeGameName(GameName.Replace("'", "").Replace(",", ""));
         }
         #endregion
     }


### PR DESCRIPTION
adding comma to the pre normalization altering. "Warhammer 40,000: Space Marine 2" results in "warhammer 40 000 space marine 2" which gives no results, but "warhammer 40000 space marine 2" does give results. Will probably help with all Warhammer 40,000 titles