### PR TITLE
Implemented default date check

### DIFF
--- a/source/Clients/EpicAchievements.cs
+++ b/source/Clients/EpicAchievements.cs
@@ -52,7 +52,7 @@ namespace SuccessStory.Clients
                                 Description = x.Description,
                                 UrlUnlocked = x.UrlUnlocked,
                                 UrlLocked = x.UrlLocked,
-                                DateUnlocked = x.DateUnlocked,
+                                DateUnlocked = x.DateUnlocked.ToString().Contains(default(DateTime).ToString()) ? (DateTime?)null : x.DateUnlocked,
                                 Percent = x.Percent,
                                 GamerScore = x.GamerScore
                             }).ToList();

--- a/source/Clients/GogAchievements.cs
+++ b/source/Clients/GogAchievements.cs
@@ -43,7 +43,7 @@ namespace SuccessStory.Clients
                             Description = x.Description,
                             UrlUnlocked = x.UrlUnlocked,
                             UrlLocked = x.UrlLocked,
-                            DateUnlocked = x.DateUnlocked,
+                            DateUnlocked = x.DateUnlocked.ToString().Contains(default(DateTime).ToString()) ? (DateTime?)null : x.DateUnlocked,
                             Percent = x.Percent,
                             GamerScore = x.GamerScore
                         }).ToList();

--- a/source/Clients/OriginAchievements.cs
+++ b/source/Clients/OriginAchievements.cs
@@ -51,7 +51,7 @@ namespace SuccessStory.Clients
                             Description = x.Description,
                             UrlUnlocked = x.UrlUnlocked,
                             UrlLocked = x.UrlLocked,
-                            DateUnlocked = x.DateUnlocked,
+                            DateUnlocked = x.DateUnlocked.ToString().Contains(default(DateTime).ToString()) ? (DateTime?)null : x.DateUnlocked,
                             Percent = x.Percent,
                             GamerScore = x.GamerScore
                         }).ToList();

--- a/source/Clients/PSNAchievements.cs
+++ b/source/Clients/PSNAchievements.cs
@@ -192,7 +192,7 @@ namespace SuccessStory.Clients
                             Name = trophie.trophyName.IsNullOrEmpty() ? ResourceProvider.GetString("LOCSuccessStoryHiddenTrophy") : trophie.trophyName,
                             Description = trophie.trophyDetail,
                             UrlUnlocked = trophie.trophyIconUrl.IsNullOrEmpty() ? "hidden_trophy.png" : trophie.trophyIconUrl,
-                            DateUnlocked = (trophieUser?.earnedDateTime == null) ? default(DateTime) : trophieUser.earnedDateTime,
+                            DateUnlocked = (trophieUser?.earnedDateTime == null) ? (DateTime?) null : trophieUser.earnedDateTime,
                             Percent = Percent == 0 ? 100 : Percent,
                             GamerScore = GamerScore
                         });

--- a/source/Clients/RetroAchievements.cs
+++ b/source/Clients/RetroAchievements.cs
@@ -828,7 +828,7 @@ namespace SuccessStory.Clients
                                 Description = (string)it["Description"],
                                 UrlLocked = string.Format(BaseUrlLocked, (string)it["BadgeName"]),
                                 UrlUnlocked = string.Format(BaseUrlUnlocked, (string)it["BadgeName"]),
-                                DateUnlocked = (it["DateEarned"] == null) ? default : Convert.ToDateTime((string)it["DateEarned"]),
+                                DateUnlocked = (it["DateEarned"] == null) ? (DateTime?) null : Convert.ToDateTime((string)it["DateEarned"]),
                                 Percent = it["NumAwarded"] == null || (int)it["NumAwarded"] == 0 || NumDistinctPlayersCasual == 0 ? 100 : (int)it["NumAwarded"] * 100 / NumDistinctPlayersCasual,
                                 GamerScore = it["Points"] == null ? 0 : (int)it["Points"]
                             });

--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -106,7 +106,7 @@ namespace SuccessStory.Clients
                         Description = x.Description,
                         UrlUnlocked = x.UrlUnlocked,
                         UrlLocked = x.UrlLocked,
-                        DateUnlocked = x.DateUnlocked,
+                        DateUnlocked = x.DateUnlocked.ToString().Contains(default(DateTime).ToString()) ? (DateTime?) null : x.DateUnlocked,
                         IsHidden = x.IsHidden,
                         Percent = x.Percent,
                         GamerScore = x.GamerScore

--- a/source/Clients/XboxAchievements.cs
+++ b/source/Clients/XboxAchievements.cs
@@ -348,7 +348,7 @@ namespace SuccessStory.Clients
                 Description = (xboxAchievement.progression.timeUnlocked == default) ? xboxAchievement.lockedDescription : xboxAchievement.description,
                 IsHidden = xboxAchievement.isSecret,
                 Percent = 100,
-                DateUnlocked = xboxAchievement.progression.timeUnlocked,
+                DateUnlocked = xboxAchievement.progression.timeUnlocked.ToString().Contains(default(DateTime).ToString()) ? (DateTime?)null : xboxAchievement.progression.timeUnlocked,
                 UrlLocked = string.Empty,
                 UrlUnlocked = xboxAchievement.mediaAssets[0].url,
                 GamerScore = float.Parse(xboxAchievement.rewards?.FirstOrDefault(x => x.type.IsEqual("Gamerscore"))?.value ?? "0")
@@ -366,7 +366,7 @@ namespace SuccessStory.Clients
                 Description = unlocked ? xboxAchievement.lockedDescription : xboxAchievement.description,
                 IsHidden = xboxAchievement.isSecret,
                 Percent = 100,
-                DateUnlocked = unlocked ? xboxAchievement.timeUnlocked : default,
+                DateUnlocked = unlocked ? xboxAchievement.timeUnlocked : (DateTime?)null,
                 UrlLocked = string.Empty,
                 UrlUnlocked = $"https://image-ssl.xboxlive.com/global/t.{xboxAchievement.titleId:x}/ach/0/{xboxAchievement.imageId:x}",
                 GamerScore = xboxAchievement.gamerscore


### PR DESCRIPTION
Added a default date check so achievements do not appear as all unlocked.
Works for 

- Steam
- Playstation
- RetroAchievements

Should work for Epic and Xbox too but Epic returns 01-Jan-01 even for unlocked achievements