### PR TITLE
Fix achievement fetch failing if earned_time for goldberg is a string

### DIFF
--- a/source/Clients/SteamEmulators.cs
+++ b/source/Clients/SteamEmulators.cs
@@ -647,11 +647,16 @@ namespace SuccessStory.Clients
                                         Name = achievement.Path;
 
                                         dynamic elements = achievement.First;
-                                        dynamic unlockedTimeToken = elements.SelectToken("earned_time");
+                                        dynamic unlockedTimeToken = elements.SelectToken("earned_time").Value;
 
-                                        if (unlockedTimeToken.Value > 0)
+                                        if (unlockedTimeToken is string)
                                         {
-                                            DateUnlocked = new DateTime(1970, 1, 1).AddSeconds(unlockedTimeToken.Value);
+                                            unlockedTimeToken = UInt64.Parse(unlockedTimeToken);
+                                        }
+
+                                        if (unlockedTimeToken > 0)
+                                        {
+                                            DateUnlocked = new DateTime(1970, 1, 1).AddSeconds(unlockedTimeToken);
                                         }
 
                                         if (Name != string.Empty && DateUnlocked != null)


### PR DESCRIPTION
This is valid for Achievement Watcher but fails in SuccessStory