### PR TITLE
Fix SteamEmu local achievements not updating properly

### DIFF
--- a/source/Clients/SteamEmulators.cs
+++ b/source/Clients/SteamEmulators.cs
@@ -648,6 +648,7 @@ namespace SuccessStory.Clients
                                 break;
 
                             case "%appdata%\\goldberg steamemu saves":
+                            case "%appdata%\\gse saves":
                                 if (File.Exists(Environment.ExpandEnvironmentVariables(DirAchivements) + $"\\{appId}\\achievements.json"))
                                 {
                                     string Name = string.Empty;
@@ -1005,7 +1006,7 @@ namespace SuccessStory.Clients
                                 Description = x.Description,
                                 UrlUnlocked = x.UrlUnlocked,
                                 UrlLocked = x.UrlLocked,
-                                DateUnlocked = x.DateUnlocked,
+                                DateUnlocked = ReturnAchievements[j].DateUnlocked,
                                 GamerScore = x.GamerScore
                             };
 


### PR DESCRIPTION
Fixes #616, #518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed achievement unlock date preservation during data synchronization operations
* Added support for an additional save file location directory

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->