### PR TITLE
Fix Steam achievements from always being disabled

### DIFF
--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -505,6 +505,11 @@ namespace SuccessStory.Clients
             return SteamApi.IsConfigured();
         }
 
+        public override bool EnabledInSettings()
+        {
+            return PluginDatabase.PluginSettings.Settings.EnableSteam;
+        }
+
         #endregion
 
         /// <summary>


### PR DESCRIPTION
Fixes #695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to enable or disable Steam achievements integration through the application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->